### PR TITLE
Fix error for delete button

### DIFF
--- a/app.R
+++ b/app.R
@@ -153,7 +153,7 @@ deleteData <- reactive({
   
   quary <- lapply(row_selection, function(nr){
     
-    dbExecute(pool, sprintf('DELETE FROM "responses_df" WHERE "row_id" == ("%s")', nr))
+    dbExecute(pool, sprintf('DELETE FROM "responses_df" WHERE "row_id" == (\'%s\')', nr))
   })
 })
 


### PR DESCRIPTION
changed double quotes to single quotes. most db use double quotes as column names.