### PR TITLE
Order of header label

### DIFF
--- a/app.R
+++ b/app.R
@@ -254,7 +254,7 @@ observeEvent(input$submit_edit, priority = 20, {
 output$responses_table <- DT::renderDataTable({
   
   table <- responses_df() %>% select(-row_id) 
-  names(table) <- c("Date", "Name", "Sex", "Age", "Comment")
+  names(table) <- c("Name", "Sex", "Age", "Comment", "Date")
   table <- datatable(table, 
                      rownames = FALSE,
                      options = list(searching = FALSE, lengthChange = FALSE)


### PR DESCRIPTION
The label order should be the same as the field order of the responses_df, that is:
 names(table) <- c("Name", "Sex", "Age", "Comment", "Date")

Otherwise, there is a mismatch (old version: greyed in screenshot; this PR: white).
![image](https://github.com/user-attachments/assets/20bf0096-d08d-4978-9145-1fc483079d85)

(test done starting with no db.sqlite file)